### PR TITLE
Add BERT-CRF

### DIFF
--- a/config/bert-crf.jsonnet
+++ b/config/bert-crf.jsonnet
@@ -1,0 +1,68 @@
+local cuda_device = 0;
+local batch_size = 10;
+local bert_embedding_dim = 1024;
+local bert_model = "bert-large-cased";
+local lr = 5e-7;
+local lstm_num_layers = 2;
+local lstm_hidden_size = 768;
+local max_length = 512;
+local num_epochs = 150;
+local optimizer = 'adam';
+
+
+{
+  "dataset_reader": {
+    "type": "conll2003",
+    "tag_label": "ner",
+    "coding_scheme": "BIOUL",
+    "token_indexers": {
+      "tokens": {
+        "type": "pretrained_transformer_mismatched",
+        "model_name": bert_model,
+        "max_length": max_length,
+      },
+    }
+  },
+  "datasets_for_vocab_creation": ["train"],
+  "train_data_path": "./data/eng.train",
+  "validation_data_path": "./data/eng.testa",
+  "test_data_path": "./data/eng.testb",
+  "evaluate_on_test": true,
+  "model": {
+    "type": "crf_tagger",
+    "label_encoding": "BIOUL",
+    "calculate_span_f1": true,
+    "text_field_embedder": {
+      "token_embedders": {
+        "tokens": {
+          "type": "pretrained_transformer_mismatched",
+          "model_name": bert_model,
+          "max_length": max_length,
+        },
+      },
+    },
+    "encoder": {
+        "type": "lstm",
+        "input_size": bert_embedding_dim,
+        "hidden_size": bert_embedding_dim / 2,
+        "bidirectional": true,
+        "num_layers": lstm_num_layers,
+    },
+  },
+  "data_loader": {
+    "batch_size": batch_size,
+  },
+  "trainer": {
+    "optimizer": {
+      "type": optimizer,
+      "lr": lr,
+    },
+    "checkpointer": {
+      "num_serialized_models_to_keep": 3,
+    },
+    "validation_metric": "+f1-measure-overall",
+    "num_epochs": num_epochs,
+    "patience": 25,
+    "cuda_device": cuda_device,
+  }
+}


### PR DESCRIPTION
```
{
  "best_epoch": 149,                                              
  "peak_cpu_memory_MB": 5133.188,                                 
  "peak_gpu_0_memory_MB": 13798,                                  
  "training_duration": "16:08:45.017616",                         
  "training_start_epoch": 0,                                      
  "training_epochs": 149,                                         
  "epoch": 149,                                                   
  "training_accuracy": 0.999906689388619,                         
  "training_accuracy3": 0.9999508891519048,                       
  "training_precision-overall": 0.9994468085106383,               
  "training_recall-overall": 0.9994893399719137,                  
  "training_f1-measure-overall": 0.999468073788754,               
  "training_loss": 0.056736886374042554,                          
  "training_reg_loss": 0.0,                                       
  "training_cpu_memory_MB": 5133.188,                             
  "training_gpu_0_memory_MB": 11460,                              
  "validation_accuracy": 0.9916669911607804,                      
  "validation_accuracy3": 0.9946847864179744,                     
  "validation_precision-overall": 0.9568056253139126,             
  "validation_recall-overall": 0.9617973746213396,                
  "validation_f1-measure-overall": 0.9592950062945366,            
  "validation_loss": 10.203736529717078,                          
  "validation_reg_loss": 0.0,                                     
  "best_validation_accuracy": 0.9916669911607804,                 
  "best_validation_accuracy3": 0.9946847864179744,                
  "best_validation_precision-overall": 0.9568056253139126,        
  "best_validation_recall-overall": 0.9617973746213396,           
  "best_validation_f1-measure-overall": 0.9592950062945366,       
  "best_validation_loss": 10.203736529717078,                     
  "best_validation_reg_loss": 0.0,                                
  "test_accuracy": 0.9814148810164747,                            
  "test_accuracy3": 0.9881770216431571,                           
  "test_precision-overall": 0.9097112860892388,                   
  "test_recall-overall": 0.9205028328611898,                      
  "test_f1-measure-overall": 0.915075244213626,                   
  "test_loss": 21.050982478037046                                 
}                               
```                                  